### PR TITLE
Add GitHub community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,115 @@
+name: Report a Banksia problem
+description: Report a reproducible defect or a blocker in the first-run path.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Banksia.
+
+        Use this form for a reproducible defect or a concrete first-run blocker.
+        Use [Discussions](https://github.com/ringlochid/banksia/discussions) for
+        open-ended questions, workflow ideas, and Results you want to share.
+
+        This issue will be public. Include only the smallest redacted evidence
+        needed to understand the problem.
+
+  - type: dropdown
+    id: stopped-at
+    attributes:
+      label: Where did you encounter the problem?
+      options:
+        - Installation
+        - Provider configuration or readiness
+        - Workflow drafting or validation
+        - Workflow publication
+        - Run start
+        - Running work or Needs your attention
+        - Result or referenced files
+        - Second run or Workflow reuse
+        - Another part of Banksia
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened, and what did you expect?
+      description: Describe the observed behavior, the expected behavior, and why this stopped or harmed the work.
+      placeholder: |
+        Observed:
+
+        Expected:
+
+        Impact:
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce it?
+      description: Give the smallest exact sequence. If it is intermittent, say so and describe the pattern you have observed.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Select ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Banksia version
+      description: Paste the output of `banksia --version`.
+      placeholder: "banksia 0.x.y"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Linux
+        - macOS
+        - WSL2
+        - Native Windows (not currently supported)
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Provider route
+      description: Choose the route involved, or say that the problem is not provider-related.
+      options:
+        - Codex
+        - Claude
+        - OpenClaw
+        - Not configured yet
+        - Not provider-related
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Smallest redacted diagnostic evidence
+      description: Paste only relevant errors or redacted output from commands such as `banksia status --json` or `banksia providers status`. Do not include credentials, private file contents, full provider transcripts, or a database dump.
+      render: shell
+
+  - type: checkboxes
+    id: public-report-safety
+    attributes:
+      label: Public report safety
+      description: Confirm both items before submitting this public issue.
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: I removed credentials, tokens, sensitive paths or content, and unnecessary private data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a usage question
+    url: https://github.com/ringlochid/banksia/discussions/categories/q-a
+    about: Ask for help when you are unsure whether the behavior is a defect.
+  - name: Discuss a manual agent workflow
+    url: https://github.com/ringlochid/banksia/discussions/categories/general
+    about: Share work you currently coordinate across Codex or Claude by hand.
+  - name: Show a Result
+    url: https://github.com/ringlochid/banksia/discussions/categories/show-and-tell
+    about: Share what a Banksia team accomplished or learned.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Outcome
+
+<!-- What user, product, or maintainer outcome does this change produce? -->
+
+## Contract and scope
+
+<!-- Link the smallest owning contract. A related issue or Discussion is useful but not mandatory. -->
+
+- Owning contract:
+- Related issue or Discussion:
+- User-visible change:
+
+## What changed
+
+<!-- Summarize the bounded implementation, documentation, tests, or other evidence. -->
+
+## Proof
+
+<!-- List exact commands and results. Name every applicable lane you skipped and its concrete blocker. -->
+
+- Commands and results:
+- Skipped lanes and reason:
+- Console screenshots or recording, if applicable:
+
+## Review notes
+
+<!-- Record residual risk, migration/reset/package implications, or a concrete follow-up owner. Write "None" when there is nothing to add. -->
+
+- Risks or follow-up:
+
+## Checklist
+
+- [ ] I read `CONTRIBUTING.md` and the owning contract before changing the implementation.
+- [ ] I kept this pull request to one coherent slice and updated contracts, tests, and generated surfaces where applicable.
+- [ ] I reviewed the complete diff and ran `git diff --check`.

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 .env.development
 venv/
 
-# Hidden local state (covers .venv, .vscode, caches, etc.); keep agent standards tracked
+# Hidden local state (covers .venv, .vscode, caches, etc.); keep intentional repo metadata tracked
 .*/
 !.agents/
+!.github/
 
 # Python caches and coverage
 __pycache__/


### PR DESCRIPTION
## Outcome

Add lightweight GitHub contribution surfaces so users can report actionable Banksia problems and contributors can present bounded, reviewable changes.

## Contract and scope

- Owning contract: `CONTRIBUTING.md` and GitHub's community-template contracts
- Related Discussions:
  - [What manual agent workflow should Banksia run?](https://github.com/ringlochid/banksia/discussions/2)
  - [Show a Result: what did your team accomplish?](https://github.com/ringlochid/banksia/discussions/3)
- User-visible change: after merge, the New Issue chooser and new pull-request bodies will provide Banksia-specific guidance

## What changed

- added one structured problem/first-run-blocker Issue Form;
- kept blank Issues available while routing questions and stories to Discussions;
- added one concise pull-request template aligned with `CONTRIBUTING.md`; and
- allowed intentional `.github/` metadata through the repository's hidden-directory ignore rule.

## Proof

- `make check-docs` — passed, including 61 docs-tooling tests;
- focused YAML and Issue Form structural checks — passed for required keys, supported element types, unique field IDs, existing label, and live Discussion category slugs;
- `git diff --check` — passed;
- backend, database, Console, browser, package, and reset lanes were not applicable because this slice changes only GitHub community metadata and the matching ignore exception.

## Review notes

- GitHub currently documents Issue Forms as public preview.
- The Issue Form and pull-request template become active only after this branch is merged into the default branch.
- The two Discussions are separate live GitHub records and are linked above.
- GitHub's public GraphQL API can create Discussions but does not expose pinning; the optional global/category pins require the web UI.

## Checklist

- [x] I read `CONTRIBUTING.md` and the owning product language before changing the repository.
- [x] I kept this pull request to one coherent community-health slice.
- [x] I reviewed the complete diff and ran `git diff --check`.
