### PR TITLE
fix: wait through transient service stops

### DIFF
--- a/src/banksia/platform/managed_services/controller_status.py
+++ b/src/banksia/platform/managed_services/controller_status.py
@@ -47,6 +47,7 @@ def wait_for_controller_state(
     pending_states = {
         ManagedServiceControllerState.FAILED,
         ManagedServiceControllerState.STARTING,
+        ManagedServiceControllerState.STOPPED,
     }
     while result.controller_state in pending_states:
         remaining_seconds = deadline - time.monotonic()

--- a/tests/unit/platform/test_managed_services.py
+++ b/tests/unit/platform/test_managed_services.py
@@ -145,10 +145,20 @@ def test_systemd_crash_loop_is_failed_instead_of_indefinitely_starting(
     }
 
 
-def test_readiness_poll_recovers_from_a_transient_native_failure(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "transient_state",
+    (
+        ManagedServiceExecutionState.FAILED,
+        ManagedServiceExecutionState.STOPPED,
+    ),
+)
+def test_readiness_poll_recovers_from_a_transient_native_state(
+    tmp_path: Path,
+    transient_state: ManagedServiceExecutionState,
+) -> None:
     inspections = iter(
         (
-            _inspection(ManagedServiceExecutionState.FAILED),
+            _inspection(transient_state),
             _inspection(ManagedServiceExecutionState.RUNNING),
         )
     )
@@ -167,13 +177,9 @@ def test_readiness_poll_recovers_from_a_transient_native_failure(tmp_path: Path)
         timeout_seconds=1,
         interval_seconds=0,
         probe=lambda host, port, state: (
-            ManagedServiceControllerState.FAILED
-            if state is ManagedServiceExecutionState.FAILED
-            else (
-                ManagedServiceControllerState.READY
-                if state is ManagedServiceExecutionState.RUNNING
-                else ManagedServiceControllerState.STARTING
-            )
+            ManagedServiceControllerState.READY
+            if state is ManagedServiceExecutionState.RUNNING
+            else ManagedServiceControllerState(state.value)
         ),
     )
 


### PR DESCRIPTION
## Summary

- keep startup readiness polling through launchd's transient stopped state
- preserve the existing bounded timeout and terminal result
- cover transient failed and stopped native observations

## Evidence

- macOS compatibility failed twice because restart observed stopped between clean shutdown and the new launchd process
- focused platform and CLI service tests: 23 passed, 4 skipped
- Ruff and focused mypy: passed